### PR TITLE
modified for (int i=1; i<= sheet.LastRowNum; i++) {

### DIFF
--- a/Assets/Terasurware/Editor/ExportTemplate.txt
+++ b/Assets/Terasurware/Editor/ExportTemplate.txt
@@ -38,7 +38,7 @@ public class $ExportTemplate$ : AssetPostprocessor {
 					$ExcelData$.Sheet s = new $ExcelData$.Sheet ();
 					s.name = sheetName;
 				
-					for (int i=1; i< sheet.LastRowNum; i++) {
+					for (int i=1; i<= sheet.LastRowNum; i++) {
 						IRow row = sheet.GetRow (i);
 						ICell cell = null;
 						


### PR DESCRIPTION
<=にしないとシートの最後の行が記入されないようです。