### PR TITLE
Add line endings normalization

### DIFF
--- a/Assets/Terasurware/Editor/ExcelImporterMaker.cs
+++ b/Assets/Terasurware/Editor/ExcelImporterMaker.cs
@@ -219,6 +219,7 @@ public class ExcelImporterMaker : EditorWindow
     {
         string templateFilePath = (sepalateSheet) ? "Assets/Terasurware/Editor/EntityTemplate2.txt" : "Assets/Terasurware/Editor/EntityTemplate.txt";
         string entittyTemplate = File.ReadAllText(templateFilePath);
+        entittyTemplate = entittyTemplate.Replace("\r\n", "\n").Replace("\n", System.Environment.NewLine);
         StringBuilder builder = new StringBuilder();
         bool isInbetweenArray = false;
         foreach (ExcelRowParameter row in typeList)


### PR DESCRIPTION
Since template files (Assets/Terasurware/Editor/EntityTemplate*.txt) have `\n` (0x0a) as line ending, output of ExcelImporterMaker contains different line endings  in Windows environment.  Because template generator emits `0x0a` for template part, and `0x0d,0x0a` for generated part (`StringBuilder.AppendLine()`).

This PR fixes it by normalizing and replacing line endings properly.

edit:  When users use git or some source code tools which can take caring for line endings, this problem is not occured.  But if users use file archive such as `.unitypackage`, they hit this issue.