### PR TITLE
本来文字列のセルで、一部が数値などの場合にも止まらないようにしました

### DIFF
--- a/Assets/Terasurware/Editor/EntityTemplate.txt
+++ b/Assets/Terasurware/Editor/EntityTemplate.txt
@@ -2,6 +2,43 @@
 using System.Collections;
 using System.Collections.Generic;
 
+public static class ICellExt {
+    public static string ForceStringCellValue(this ICell cell)
+    {
+        string s = null;
+        switch (cell.CellType)
+        {
+            case CellType.Blank:
+                s = "";
+                break;
+            case CellType.Boolean:
+                s = cell.BooleanCellValue + "";
+                break;
+            case CellType.Error:
+                s = cell.ErrorCellValue + "";
+                break;
+            case CellType.Formula:
+                s = cell.CellFormula;
+                break;
+            case CellType.Numeric:
+                s = cell.NumericCellValue + "";
+                break;
+            case CellType.String:
+                return cell.StringCellValue;
+            case CellType.Unknown:
+                s = "??? CellType.Unknown";
+                break;
+            default:
+                Debug.LogError($"can't happen at sheet {cell.Sheet} row {cell.Row}");
+                return "??? UNKNOWN " + cell.CellType;
+        }
+        Debug.LogWarning($"expected STRING cell, but {cell.CellType} is found at "
+                        + $"sheet:{cell.Sheet.SheetName} row:{cell.Row.RowNum} column:{cell.ColumnIndex} s:[{s}]");
+        // return s + " (warn: force converted)";
+        return s;
+    }
+}
+
 public class $ExcelData$ : ScriptableObject
 {	
 	public List<Sheet> sheets = new List<Sheet> ();

--- a/Assets/Terasurware/Editor/ExcelImporterMaker.cs
+++ b/Assets/Terasurware/Editor/ExcelImporterMaker.cs
@@ -299,7 +299,7 @@ public class ExcelImporterMaker : EditorWindow
 							builder.AppendFormat(tab + "cell = row.GetCell({1}); p.{0} = (float)(cell == null ? 0 : cell.NumericCellValue);", row.name, rowCount);
 							break;
 						case ValueType.STRING:
-                            builder.AppendFormat(tab + "cell = row.GetCell({1}); p.{0} = (cell == null ? \"\" : cell.StringCellValue);", row.name, rowCount);
+                            builder.AppendFormat(tab + "cell = row.GetCell({1}); p.{0} = (cell == null ? \"\" : cell.ForceStringCellValue());", row.name, rowCount);
                             break;
 					}
                 } else
@@ -351,7 +351,7 @@ public class ExcelImporterMaker : EditorWindow
 									builder.AppendFormat(tab + "cell = row.GetCell({1}); p.{0}[{2}] = (float)(cell == null ? 0.0 : cell.NumericCellValue);", row.name, rowCount + i, i);
 									break;
                                 case ValueType.STRING:
-                                    builder.AppendFormat(tab + "cell = row.GetCell({1}); p.{0}[{2}] = (cell == null ? \"\" : cell.StringCellValue);", row.name, rowCount + i, i);
+                                    builder.AppendFormat(tab + "cell = row.GetCell({1}); p.{0}[{2}] = (cell == null ? \"\" : cell.ForceStringCellValue());", row.name, rowCount + i, i);
                                     break;
                             }
                         }


### PR DESCRIPTION
とても便利に使っています。ありがとうございます。
外部の方（非ゲーム開発者）に作ってもらったエクセルを読み込む時に、ほとんどの場合は文字列のセルですが、ごく一部だけ数値になっている場合がありました。エクセルの方を修正してもいいのですが、修正してもらう箇所を特定するためにも、見つけたら警告を出して、とりあえず強制的に変換してしのぐようにした変更です。
あまり良い変更ではないかもしれませんが、一応プルリク出しておきます。